### PR TITLE
Add ignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Features:
 + Can detect exactly what errors were introduced and what errors were resolved, even if they are in the same file.
 + Baseline is carefully crafted to avoid merge conflicts.
 + Baseline is human-readable, and diffs are informative. The reviewers of your PR will know exactly what errors you resolve and what errors you introduced.
++ Track the progress you make with git-based history of changes and burndown chart of resolved type violations.
++ Ignore speicific error messages (using regular expressions), so that buggy mypy plugins don't bother you with false-positives.
 
 ## Installation
 
@@ -64,6 +66,8 @@ preserve_position = False
 hide_stats = False
 # --no-colors: do not use colors in stats
 no_colors = False
+# --ignore: regexes for error messages to ignore
+ignore = []
 ```
 
 ## History

--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -20,6 +20,7 @@ REX_LINE = re.compile(rf"""
     (?:\s\s{COLOR_PATTERN}\[(?P<category>[a-z-]+)\]{COLOR_PATTERN})?
     \s*
 """, re.VERBOSE | re.MULTILINE)
+REX_LINE_IN_MSG = re.compile(r'defined on line \d+')
 
 
 @dataclass
@@ -60,6 +61,7 @@ class Error:
         path = Path(*self.path.parts[:config.depth])
         pos = self.line_number if config.preserve_position else 0
         msg = REX_COLOR.sub('', self.message).strip()
+        msg = REX_LINE_IN_MSG.sub('defined on line 0', msg)
         line = f'{path}:{pos}: {self.severity}: {msg}'
         if self.category != 'note':
             line += f'  [{self.category}]'

--- a/mypy_baseline/commands/_filter.py
+++ b/mypy_baseline/commands/_filter.py
@@ -95,7 +95,6 @@ class Filter(Command):
                 new_formatted = f'{new: >+3}'
                 line += f' {self.colors.red(new_formatted)}'
             self.print(line)
-        self.print()
 
         msg = self.colors.get_exit_message(fixed=fixed_count, new=new_count)
         self.print(msg)

--- a/mypy_baseline/commands/_filter.py
+++ b/mypy_baseline/commands/_filter.py
@@ -25,6 +25,8 @@ class Filter(Command):
             if error is None:
                 self.print(line, end='')
                 continue
+            if self.config.is_ignored(error.message):
+                continue
             clean_line = error.get_clean_line(self.config)
             try:
                 baseline.remove(clean_line)

--- a/mypy_baseline/commands/_sync.py
+++ b/mypy_baseline/commands/_sync.py
@@ -15,20 +15,22 @@ class Sync(Command):
             baseline_text = ''
         old_baseline = baseline_text.splitlines()
 
-        baseline: list[str] = []
+        new_baseline: list[str] = []
         for line in self.stdin:
             error = Error.new(line)
             if error is None:
                 self.print(line, end='')
                 continue
+            if self.config.is_ignored(error.message):
+                continue
             clean_line = error.get_clean_line(self.config)
-            baseline.append(clean_line)
+            new_baseline.append(clean_line)
 
         synced = False
         if old_baseline:
-            synced = self._stable_sync(old_baseline, baseline)
+            synced = self._stable_sync(old_baseline, new_baseline)
         if not synced:
-            self._write_baseline(baseline)
+            self._write_baseline(new_baseline)
         return 0
 
     def _stable_sync(self, old_bline: list[str], new_bline: list[str]) -> bool:


### PR DESCRIPTION
Now you can specify `ignore` option in the config that will exclude all type violations matching any of the given regular expressions.