### PR TITLE
Out-of-the-box GitLab support

### DIFF
--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -6,15 +6,15 @@ The `mypy-baseline suggest` command checks if your current branch fixes enough e
 mypy-baseline suggest
 ```
 
+## CI
+
 The command is designed to be integrated with CI, and will do its best to correctly detect the target branch and produce stable results for the same PR.
 
-## GitLab
-
-The command provide a native integration with GitLab that adds comments to MRs. To use it from a GitLab CI:
+Also, there is a native integration with GitLab CI that adds suggestions as comments to MRs. To use it:
 
 1. Set `GITLAB_CI` environment variable with an [access token](https://gitlab.com/-/profile/personal_access_tokens) of the user that should be used to add the comment.
 1. Install [requests](https://requests.readthedocs.io/en/latest/): `python3 -m pip install requests`
-1. Run `mypy-baseline suggest --comment`.
+1. Run `mypy-baseline suggest` with `--comment` flag.
 
 For example:
 
@@ -33,3 +33,5 @@ mypy-baseline suggest:
       --default-branch=origin/master
       --comment
 ```
+
+With other CI providers, you can try piping the command output into [reviewdog](https://github.com/reviewdog/reviewdog).

--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -8,12 +8,28 @@ mypy-baseline suggest
 
 The command is designed to be integrated with CI, and will do its best to correctly detect the target branch and produce stable results for the same PR.
 
-To improve user experience, you can pipe the output into [reviewdog](https://github.com/reviewdog/reviewdog) to get suggestions as review comments:
+## GitLab
 
-```bash
-mypy-baseline suggest | reviewdog \
-    -efm='%f:%l: %m' \
-    -name=mypy-baseline \
-    -reporter=gitlab-mr-discussion \
-    -filter-mode=nofilter
+The command provide a native integration with GitLab that adds comments to MRs. To use it from a GitLab CI:
+
+1. Set `GITLAB_CI` environment variable with an [access token](https://gitlab.com/-/profile/personal_access_tokens) of the user that should be used to add the comment.
+1. Install [requests](https://requests.readthedocs.io/en/latest/): `python3 -m pip install requests`
+1. Run `mypy-baseline suggest --comment`.
+
+For example:
+
+```yaml
+mypy-baseline suggest:
+  # ...
+  rules:
+    - if: "$CI_MERGE_REQUEST_ID"
+  before_script:
+    - python -m pip install mypy-baseline requests
+  script:
+    - git fetch origin master
+    - >
+      mypy-baseline suggest
+      --exit-zero
+      --default-branch=origin/master
+      --comment
 ```

--- a/mypy_baseline/commands/_suggest.py
+++ b/mypy_baseline/commands/_suggest.py
@@ -6,6 +6,7 @@ import subprocess
 from argparse import ArgumentParser
 from functools import cached_property
 from pathlib import Path
+from textwrap import dedent
 from typing import Iterable
 
 from .._config import Config
@@ -47,16 +48,19 @@ class Suggest(Command):
             '--exit-zero', action='store_true',
             help='always return zero exit code',
         )
+        parser.add_argument(
+            '--comment', action='store_true',
+            help='add comment to the GitLab MR discussion',
+        )
 
     def run(self) -> int:
         if self.fixed_count >= self.args.min_fixed:
             return 0
-        suggested = self.suggested
-        # reviewdog for GitLab requires line number to be 1+.
-        # https://github.com/reviewdog/reviewdog/issues/760
-        suggested.line_number = 1
-        result = suggested.get_clean_line(Config(preserve_position=True))
+        config = Config(preserve_position=True)
+        result = self.suggested.get_clean_line(config)
         self.print(result)
+        if self.args.comment:
+            self._post_to_gitlab(result)
         if self.args.exit_zero:
             return 0
         return 1
@@ -174,3 +178,65 @@ class Suggest(Command):
             if pr_id:
                 return pr_id
         return ''
+
+    def _post_to_gitlab(self, err_msg: str) -> None:
+        """Add a comment to the GitLab MR for which the job runs.
+        """
+        import requests
+
+        # get API token
+        is_gitlab = os.environ.get('GITLAB_CI')
+        if not is_gitlab:
+            raise LookupError('Not running on GitLab CI')
+        token = os.environ.get('REVIEWDOG_GITLAB_API_TOKEN')
+        if not token:
+            token = os.environ.get('GITLAB_API_TOKEN')
+        if not token:
+            raise LookupError('GITLAB_API_TOKEN env var is not set')
+
+        already_commented = self._check_gitlab_has_comment(token)
+        if already_commented:
+            return
+
+        # form the message
+        s = 's' if self.args.min_fixed > 1 else ''
+        path = self.config.baseline_path
+        msg = f"""
+            ## mypy-baseline suggest
+
+            Please, resolve {self.args.min_fixed}+ error{s} from `{path}`. Suggested:
+
+            ```
+            {err_msg}
+            ```
+        """
+
+        # send the request
+        requests.post(
+            url=self._gitlab_comment_url,
+            json={'body': dedent(msg)},
+            headers={'PRIVATE-TOKEN': token},
+        )
+
+    def _check_gitlab_has_comment(self, token: str) -> bool:
+        """Check if mypy-baseline already left a comment in the MR.
+        """
+        import requests
+
+        resp = requests.get(self._gitlab_comment_url)
+        if not resp.ok:
+            return False
+        for comment in resp.json():
+            body: str = comment['body'].strip()
+            if body.startswith('## mypy-baseline suggest'):
+                return True
+        return False
+
+    @cached_property
+    def _gitlab_comment_url(self) -> str:
+        """GitLab API endpoint to work with MR comments.
+        """
+        base_url = os.environ['CI_API_V4_URL']
+        project_id = os.environ['CI_MERGE_REQUEST_PROJECT_ID']
+        mr_id = os.environ['CI_MERGE_REQUEST_IID']
+        return f'{base_url}/projects/{project_id}/merge_requests/{mr_id}/notes'

--- a/mypy_baseline/commands/_suggest.py
+++ b/mypy_baseline/commands/_suggest.py
@@ -201,10 +201,11 @@ class Suggest(Command):
         # form the message
         s = 's' if self.args.min_fixed > 1 else ''
         path = self.config.baseline_path
+        count = self.args.min_fixed
         msg = f"""
             ## mypy-baseline suggest
 
-            Please, resolve {self.args.min_fixed}+ error{s} from `{path}`. Suggested:
+            Please, resolve at least {count} error{s} from `{path}`. Suggested:
 
             ```
             {err_msg}
@@ -212,11 +213,12 @@ class Suggest(Command):
         """
 
         # send the request
-        requests.post(
+        resp = requests.post(
             url=self._gitlab_comment_url,
             json={'body': dedent(msg)},
             headers={'PRIVATE-TOKEN': token},
         )
+        resp.raise_for_status()
 
     def _check_gitlab_has_comment(self, token: str) -> bool:
         """Check if mypy-baseline already left a comment in the MR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,14 @@ dependencies = []
 test = [
     "pytest",
     "pytest-cov",
+    "requests",
+    "responses",
 ]
 lint = [
     "flake8",
     "isort",
     "mypy",
+    "types-requests",
     "types-toml",
     "unify",
 ]


### PR DESCRIPTION
Somehow I struggle to make reviewdog work with `mypy-baseline suggest`. The doggy doesn't show any errors but doesn't post the comment. I thought it was because https://github.com/reviewdog/reviewdog/issues/760 but nope, it's something else. Let's try to directly use GitLab API instead.