### PR TITLE
Don't suggest twice for GitLab MRs

### DIFF
--- a/mypy_baseline/commands/_suggest.py
+++ b/mypy_baseline/commands/_suggest.py
@@ -226,11 +226,12 @@ class Suggest(Command):
         import requests
 
         resp = requests.get(self._gitlab_comment_url)
-        if not resp.ok:
-            return False
+        resp.raise_for_status()
+        # if not resp.ok:
+        #     return False
         for comment in resp.json():
             body: str = comment['body'].strip()
-            if body.lstrip().startswith('## mypy-baseline suggest'):
+            if body.startswith('## mypy-baseline suggest'):
                 return True
         return False
 

--- a/mypy_baseline/commands/_suggest.py
+++ b/mypy_baseline/commands/_suggest.py
@@ -225,10 +225,11 @@ class Suggest(Command):
         """
         import requests
 
-        resp = requests.get(self._gitlab_comment_url)
+        resp = requests.get(
+            url=self._gitlab_comment_url,
+            headers={'PRIVATE-TOKEN': token},
+        )
         resp.raise_for_status()
-        # if not resp.ok:
-        #     return False
         for comment in resp.json():
             body: str = comment['body'].strip()
             if body.startswith('## mypy-baseline suggest'):


### PR DESCRIPTION
Fix the retrieval of comments for a GitLab MR (I forgot to pass the GitLab token to the request headers).