### PR TITLE
Add support for linting Jupyter notebooks through nbQA

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ After that, you can pipe mypy output into `mypy-baseline filter`, and it will fi
 mypy | mypy-baseline filter
 ```
 
+### Usage with Jupyter notebooks
+
+Jupyter notebooks can be checked with [nbQA](https://github.com/nbQA-dev/nbQA)
+Simply run
+
+```bash
+nbqa mypy <directory> | mypy-baseline <command>
+```
+
+e.g.
+
+```bash
+nbqa mypy . | mypy-baseline filter
+```
+
 If you introduce new errors, resolve them. If you resolve existing errors, run `mypy-baseline sync` again to re-generate baseline. In both cases, mypy-baseline will tell you what's wrong and what to do. Enjoy the ride!
 
 Read more in the documentation: [mypy-baseline.orsinium.dev](https://mypy-baseline.orsinium.dev/)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ e.g.
 nbqa mypy . | mypy-baseline filter
 ```
 
+To baseline both Jupyter notebooks and .py files run
+
+```bash
+(mypy .; nbqa mypy .) | mypy-baseline sync
+```
+
 If you introduce new errors, resolve them. If you resolve existing errors, run `mypy-baseline sync` again to re-generate baseline. In both cases, mypy-baseline will tell you what's wrong and what to do. Enjoy the ride!
 
 Read more in the documentation: [mypy-baseline.orsinium.dev](https://mypy-baseline.orsinium.dev/)

--- a/README.md
+++ b/README.md
@@ -39,27 +39,6 @@ After that, you can pipe mypy output into `mypy-baseline filter`, and it will fi
 mypy | mypy-baseline filter
 ```
 
-### Usage with Jupyter notebooks
-
-Jupyter notebooks can be checked with [nbQA](https://github.com/nbQA-dev/nbQA)
-Simply run
-
-```bash
-nbqa mypy <directory> | mypy-baseline <command>
-```
-
-e.g.
-
-```bash
-nbqa mypy . | mypy-baseline filter
-```
-
-To baseline both Jupyter notebooks and .py files run
-
-```bash
-(mypy .; nbqa mypy .) | mypy-baseline sync
-```
-
 If you introduce new errors, resolve them. If you resolve existing errors, run `mypy-baseline sync` again to re-generate baseline. In both cases, mypy-baseline will tell you what's wrong and what to do. Enjoy the ride!
 
 Read more in the documentation: [mypy-baseline.orsinium.dev](https://mypy-baseline.orsinium.dev/)

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -9,3 +9,12 @@ mypy | mypy-baseline sync
 The baseline file (`mypy-baseline.txt` by default) contains all errors that mypy spits out with line numbers replaced with zeros and colors removed. All errors recorded in the baseline will be filtered out from the future mypy runs by `mypy-baseline filter`.
 
 The lines in the baseline come in the same order as mypy produeces them. This order is fragile, and the order of files analyzed (and so the lines in the baseline) might change as the dependency graph between modules changes and even be different on different machines. When syncing the changes with an existing baseline, we try to preserve the lines order there, but sometimes it cannot be done, and the lines may jump around. If that causes merge conflicts, simply re-run `sync` instead of trying to fix conflicts manually.
+
+## Jupyter notebooks
+
+All mypy-baseline commands support [nbQA](https://github.com/nbQA-dev/nbQA) for checking [Jupyter notebooks](https://jupyter.org/):
+
+```bash
+python3 -m pip install nbqa
+nbqa mypy . | mypy-baseline sync
+```

--- a/mypy_baseline/__init__.py
+++ b/mypy_baseline/__init__.py
@@ -4,5 +4,5 @@
 from ._cli import entrypoint, main
 
 
-__version__ = '0.4.5'
+__version__ = '0.5.0'
 __all__ = ['entrypoint', 'main']

--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -11,17 +11,30 @@ if TYPE_CHECKING:
     from ._config import Config
 
 COLOR_PATTERN = '(\x1b\\[\\d*m?|\x0f)*'
+COLOR_PATTERN_NBQA = "\[\d*m|\\x1b|\(B"
 REX_COLOR = re.compile(COLOR_PATTERN)
-REX_LINE = re.compile(rf"""
+REX_COLOR_NBQA = re.compile(COLOR_PATTERN_NBQA)
+REX_LINE = re.compile(r"""
     (?P<path>.+\.py):
     (?P<lineno>[0-9]+):\s
-    {COLOR_PATTERN}(?P<severity>[a-z]+):{COLOR_PATTERN}\s
+    (?P<severity>[a-z]+):\s
     (?P<message>.+?)
-    (?:\s\s{COLOR_PATTERN}\[(?P<category>[a-z-]+)\]{COLOR_PATTERN})?
+    (?:\s\s\[(?P<category>[a-z-]+)\])?
+    \s*
+""", re.VERBOSE | re.MULTILINE)
+REX_LINE_NBQA = re.compile(r"""
+    (?P<path>.+\.ipynb:cell_[0-9]+):
+    (?P<lineno>[0-9]+):\s
+    (?P<severity>[a-z]+):\s
+    (?P<message>.+?)
+    (?:\s\s\[(?P<category>[a-z-]+)\])?
     \s*
 """, re.VERBOSE | re.MULTILINE)
 REX_LINE_IN_MSG = re.compile(r'defined on line \d+')
 
+def _remove_color_codes(line: str) -> str:
+    line = REX_COLOR.sub("", line)
+    return REX_COLOR_NBQA.sub( "", line)
 
 @dataclass
 class Error:
@@ -30,9 +43,13 @@ class Error:
 
     @classmethod
     def new(self, line: str) -> Error | None:
-        match = REX_LINE.fullmatch(line)
+        line = _remove_color_codes(line)
+        match = REX_LINE.fullmatch(line) or REX_LINE_NBQA.fullmatch(line)
+        
         if match is None:
             return None
+        print(match.group('lineno'))
+
         return Error(line, match)
 
     @cached_property
@@ -61,6 +78,7 @@ class Error:
         path = Path(*self.path.parts[:config.depth])
         pos = self.line_number if config.preserve_position else 0
         msg = REX_COLOR.sub('', self.message).strip()
+        msg = REX_COLOR_NBQA.sub('', self.message).strip()
         msg = REX_LINE_IN_MSG.sub('defined on line 0', msg)
         line = f'{path}:{pos}: {self.severity}: {msg}'
         if self.category != 'note':

--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -10,10 +10,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ._config import Config
 
-COLOR_PATTERN = '(\x1b\\[\\d*m?|\x0f)*'
-COLOR_PATTERN_NBQA = '\\[\\d*m|\\x1b|\\(B'
-REX_COLOR = re.compile(COLOR_PATTERN)
-REX_COLOR_NBQA = re.compile(COLOR_PATTERN_NBQA)
+REX_COLOR = re.compile('(\x1b\\[\\d*m?|\x0f)*')
+REX_COLOR_NBQA = re.compile(r'\[\d*m|\x1b|\(B')
 REX_LINE = re.compile(r"""
     (?P<path>.+\.py):
     (?P<lineno>[0-9]+):\s
@@ -47,10 +45,8 @@ class Error:
     def new(self, line: str) -> Error | None:
         line = _remove_color_codes(line)
         match = REX_LINE.fullmatch(line) or REX_LINE_NBQA.fullmatch(line)
-
         if match is None:
             return None
-
         return Error(line, match)
 
     @cached_property

--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -48,7 +48,6 @@ class Error:
         
         if match is None:
             return None
-        print(match.group('lineno'))
 
         return Error(line, match)
 

--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ._config import Config
 
 COLOR_PATTERN = '(\x1b\\[\\d*m?|\x0f)*'
-COLOR_PATTERN_NBQA = "\[\d*m|\\x1b|\(B"
+COLOR_PATTERN_NBQA = '\\[\\d*m|\\x1b|\\(B'
 REX_COLOR = re.compile(COLOR_PATTERN)
 REX_COLOR_NBQA = re.compile(COLOR_PATTERN_NBQA)
 REX_LINE = re.compile(r"""
@@ -32,9 +32,11 @@ REX_LINE_NBQA = re.compile(r"""
 """, re.VERBOSE | re.MULTILINE)
 REX_LINE_IN_MSG = re.compile(r'defined on line \d+')
 
+
 def _remove_color_codes(line: str) -> str:
-    line = REX_COLOR.sub("", line)
-    return REX_COLOR_NBQA.sub( "", line)
+    line = REX_COLOR.sub('', line)
+    return REX_COLOR_NBQA.sub('', line)
+
 
 @dataclass
 class Error:
@@ -45,7 +47,7 @@ class Error:
     def new(self, line: str) -> Error | None:
         line = _remove_color_codes(line)
         match = REX_LINE.fullmatch(line) or REX_LINE_NBQA.fullmatch(line)
-        
+
         if match is None:
             return None
 

--- a/tests/test_commands/helpers.py
+++ b/tests/test_commands/helpers.py
@@ -8,6 +8,8 @@ from mypy_baseline import main
 LINE1 = 'views.py:69: error: Hello world  [assignment]\r\n'
 LINE2 = 'settings.py:42: error: How are you?  [union-attr]\r\n'
 
+NOTEBOOK_LINE1 = 'fail.ipynb:cell_1:2: \x1b[1m\x1b[31merror:\x1b(B\x1b[m Incompatible return value type (got \x1b(B\x1b[m\x1b[1m"int"\x1b(B\x1b[m, expected \x1b(B\x1b[m\x1b[1m"str"\x1b(B\x1b[m)  \x1b(B\x1b[m\x1b[33m[return-value]\x1b(B\x1b[m\n'
+NOTEBOOK_LINE1_EXPECTED = 'fail.ipynb:cell_1:2: error: Incompatible return value type (got "int", expected "str")  [return-value]'
 
 def run(cmd: list[str], exit_code: int = 0) -> str:
     stdout = StringIO()

--- a/tests/test_commands/helpers.py
+++ b/tests/test_commands/helpers.py
@@ -8,8 +8,8 @@ from mypy_baseline import main
 LINE1 = 'views.py:69: error: Hello world  [assignment]\r\n'
 LINE2 = 'settings.py:42: error: How are you?  [union-attr]\r\n'
 
-NOTEBOOK_LINE1 = 'fail.ipynb:cell_1:2: \x1b[1m\x1b[31merror:\x1b(B\x1b[m Incompatible return value type (got \x1b(B\x1b[m\x1b[1m"int"\x1b(B\x1b[m, expected \x1b(B\x1b[m\x1b[1m"str"\x1b(B\x1b[m)  \x1b(B\x1b[m\x1b[33m[return-value]\x1b(B\x1b[m\n'
-NOTEBOOK_LINE1_EXPECTED = 'fail.ipynb:cell_1:2: error: Incompatible return value type (got "int", expected "str")  [return-value]'
+NOTEBOOK_LINE1 = 'fail.ipynb:cell_1:2: \x1b[1m\x1b[31merror:\x1b(B\x1b[m Incompatible return value type (got \x1b(B\x1b[m\x1b[1m"int"\x1b(B\x1b[m, expected \x1b(B\x1b[m\x1b[1m"str"\x1b(B\x1b[m)  \x1b(B\x1b[m\x1b[33m[return-value]\x1b(B\x1b[m\n'  # noqa: E501
+
 
 def run(cmd: list[str], exit_code: int = 0) -> str:
     stdout = StringIO()

--- a/tests/test_commands/test_filter.py
+++ b/tests/test_commands/test_filter.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 from mypy_baseline import main
 
-from .helpers import LINE1, LINE2, run, NOTEBOOK_LINE1, NOTEBOOK_LINE1_EXPECTED
+from .helpers import LINE1, LINE2, NOTEBOOK_LINE1, run
 
 
 def test_filter():
@@ -23,11 +23,12 @@ def test_filter():
     assert '  union-attr  ' in actual
     assert '  unresolved' in actual
     assert 'Your changes introduced' in actual
-    
+
+
 def test_filter_notebook():
     stdin = StringIO()
     stdin.write(NOTEBOOK_LINE1)
-    
+
     stdin.seek(0)
     stdout = StringIO()
     code = main(['filter'], stdin, stdout)

--- a/tests/test_commands/test_filter.py
+++ b/tests/test_commands/test_filter.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 from mypy_baseline import main
 
-from .helpers import LINE1, LINE2, run
+from .helpers import LINE1, LINE2, run, NOTEBOOK_LINE1, NOTEBOOK_LINE1_EXPECTED
 
 
 def test_filter():
@@ -21,6 +21,21 @@ def test_filter():
     assert LINE2.strip() in actual
     assert '  assignment  ' in actual
     assert '  union-attr  ' in actual
+    assert '  unresolved' in actual
+    assert 'Your changes introduced' in actual
+    
+def test_filter_notebook():
+    stdin = StringIO()
+    stdin.write(NOTEBOOK_LINE1)
+    
+    stdin.seek(0)
+    stdout = StringIO()
+    code = main(['filter'], stdin, stdout)
+    assert code == 1
+    stdout.seek(0)
+    actual = stdout.read()
+    assert NOTEBOOK_LINE1 in actual
+    assert '  return-value  ' in actual
     assert '  unresolved' in actual
     assert 'Your changes introduced' in actual
 

--- a/tests/test_commands/test_sync.py
+++ b/tests/test_commands/test_sync.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from mypy_baseline import main
 
-from .helpers import LINE1, LINE2
+from .helpers import LINE1, LINE2, NOTEBOOK_LINE1, NOTEBOOK_LINE1_EXPECTED
 
 
 def test_sync(tmp_path: Path):
@@ -20,3 +20,15 @@ def test_sync(tmp_path: Path):
     line1, line2 = actual.splitlines()
     assert line1 == 'views.py:0: error: Hello world  [assignment]'
     assert line2 == 'settings.py:0: error: How are you?  [union-attr]'
+    
+def test_sync(tmp_path: Path):
+    blpath = tmp_path / 'bline.txt'
+    stdin = StringIO()
+    stdin.write(NOTEBOOK_LINE1)
+    stdin.seek(0)
+    code = main(['sync', '--baseline-path', str(blpath)], stdin, StringIO())
+    assert code == 0
+    actual = blpath.read_text()
+    line1 = actual.splitlines()[0]
+    assert line1 == 'fail.ipynb:cell_1:0: error: Incompatible return value type (got "int", expected "str")  [return-value]'
+

--- a/tests/test_commands/test_sync.py
+++ b/tests/test_commands/test_sync.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from mypy_baseline import main
 
-from .helpers import LINE1, LINE2, NOTEBOOK_LINE1, NOTEBOOK_LINE1_EXPECTED
+from .helpers import LINE1, LINE2, NOTEBOOK_LINE1
 
 
 def test_sync(tmp_path: Path):
@@ -20,8 +20,9 @@ def test_sync(tmp_path: Path):
     line1, line2 = actual.splitlines()
     assert line1 == 'views.py:0: error: Hello world  [assignment]'
     assert line2 == 'settings.py:0: error: How are you?  [union-attr]'
-    
-def test_sync(tmp_path: Path):
+
+
+def test_sync_notebook(tmp_path: Path):
     blpath = tmp_path / 'bline.txt'
     stdin = StringIO()
     stdin.write(NOTEBOOK_LINE1)
@@ -30,5 +31,4 @@ def test_sync(tmp_path: Path):
     assert code == 0
     actual = blpath.read_text()
     line1 = actual.splitlines()[0]
-    assert line1 == 'fail.ipynb:cell_1:0: error: Incompatible return value type (got "int", expected "str")  [return-value]'
-
+    assert line1 == 'fail.ipynb:cell_1:0: error: Incompatible return value type (got "int", expected "str")  [return-value]'  # noqa: E501

--- a/tests/test_commands/test_top_files.py
+++ b/tests/test_commands/test_top_files.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .helpers import LINE1, LINE2, run, NOTEBOOK_LINE1
+from .helpers import LINE1, LINE2, NOTEBOOK_LINE1, run
 
 
 def test_top_files(tmp_path: Path):
@@ -12,6 +12,7 @@ def test_top_files(tmp_path: Path):
     actual = run(cmd)
     assert 'views.py' in actual
     assert 'settings.py' in actual
+
 
 def test_top_notebook(tmp_path: Path):
     blpath = tmp_path / 'bline.txt'

--- a/tests/test_commands/test_top_files.py
+++ b/tests/test_commands/test_top_files.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .helpers import LINE1, LINE2, run
+from .helpers import LINE1, LINE2, run, NOTEBOOK_LINE1
 
 
 def test_top_files(tmp_path: Path):
@@ -12,3 +12,10 @@ def test_top_files(tmp_path: Path):
     actual = run(cmd)
     assert 'views.py' in actual
     assert 'settings.py' in actual
+
+def test_top_notebook(tmp_path: Path):
+    blpath = tmp_path / 'bline.txt'
+    blpath.write_text(f'{NOTEBOOK_LINE1}')
+    cmd = ['top-files', '--baseline-path', str(blpath), '--no-color']
+    actual = run(cmd)
+    assert 'fail.ipynb' in actual


### PR DESCRIPTION
Hey,

I had issues running mypy baseline for Jupyter notebooks through [nbQA](https://github.com/nbQA-dev/nbQA). Mainly the output from mypy is slightly different (e.g. includes the cell number) and seems to be double escaped when piping from nbQA into mypy-baseline.

I added a function to strip the color characters from the input string, I believe this solution is a bit simpler, as the regex for getting the double escaped color codes would have gotten very complex.

Also added some basic tests. For me all commands seem to work fine. Let me know, if you would like anything changed