### PR TITLE
Fix too aggressive color removal

### DIFF
--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from ._config import Config
 
 REX_COLOR = re.compile('(\x1b\\[\\d*m?|\x0f)*')
-REX_COLOR_NBQA = re.compile(r'\[\d*m|\x1b|\(B')
+REX_COLOR_NBQA = re.compile(r'\[\d*\x1bm|\x1b|\(B')
 REX_LINE = re.compile(r"""
     (?P<path>.+\.py):
     (?P<lineno>[0-9]+):\s

--- a/tests/test_commands/helpers.py
+++ b/tests/test_commands/helpers.py
@@ -7,6 +7,7 @@ from mypy_baseline import main
 
 LINE1 = 'views.py:69: error: Hello world  [assignment]\r\n'
 LINE2 = 'settings.py:42: error: How are you?  [union-attr]\r\n'
+LINE3 = 'python/utils.py:15: error: Second argument of Enum() must be string  [misc]\n'
 
 NOTEBOOK_LINE1 = 'fail.ipynb:cell_1:2: \x1b[1m\x1b[31merror:\x1b(B\x1b[m Incompatible return value type (got \x1b(B\x1b[m\x1b[1m"int"\x1b(B\x1b[m, expected \x1b(B\x1b[m\x1b[1m"str"\x1b(B\x1b[m)  \x1b(B\x1b[m\x1b[33m[return-value]\x1b(B\x1b[m\n'  # noqa: E501
 

--- a/tests/test_commands/test_filter.py
+++ b/tests/test_commands/test_filter.py
@@ -4,21 +4,23 @@ from io import StringIO
 
 from mypy_baseline import main
 
-from .helpers import LINE1, LINE2, NOTEBOOK_LINE1, run
+from .helpers import LINE1, LINE2, LINE3, NOTEBOOK_LINE1, run
 
 
 def test_filter():
     stdin = StringIO()
     stdin.write(LINE1)
     stdin.write(LINE2)
+    stdin.write(LINE3)
     stdin.seek(0)
     stdout = StringIO()
     code = main(['filter'], stdin, stdout)
-    assert code == 2
+    assert code == 3
     stdout.seek(0)
     actual = stdout.read()
     assert LINE1.strip() in actual
     assert LINE2.strip() in actual
+    assert LINE3.strip() in actual
     assert '  assignment  ' in actual
     assert '  union-attr  ' in actual
     assert '  unresolved' in actual

--- a/tests/test_commands/test_sync.py
+++ b/tests/test_commands/test_sync.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from mypy_baseline import main
 
-from .helpers import LINE1, LINE2, NOTEBOOK_LINE1
+from .helpers import LINE1, LINE2, LINE3, NOTEBOOK_LINE1
 
 
 def test_sync(tmp_path: Path):
@@ -13,13 +13,15 @@ def test_sync(tmp_path: Path):
     stdin = StringIO()
     stdin.write(LINE1)
     stdin.write(LINE2)
+    stdin.write(LINE3)
     stdin.seek(0)
     code = main(['sync', '--baseline-path', str(blpath)], stdin, StringIO())
     assert code == 0
     actual = blpath.read_text()
-    line1, line2 = actual.splitlines()
+    line1, line2, line3 = actual.splitlines()
     assert line1 == 'views.py:0: error: Hello world  [assignment]'
     assert line2 == 'settings.py:0: error: How are you?  [union-attr]'
+    assert line3 == 'python/utils.py:0: error: Second argument of Enum() must be string  [misc]'  # noqa: E501s
 
 
 def test_sync_notebook(tmp_path: Path):


### PR DESCRIPTION
The color removal regex introduced in #15 consumes any `[m` match which turns `[misc]` into `isc]`.