### PR TITLE
Fix unused regex colour var, and fix bug where mypy returned no errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 /.venvs/
 /docs/assets
 /docs/build/
+.python-version
+.idea/
+.coverage

--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -75,7 +75,7 @@ class Error:
         path = Path(*self.path.parts[:config.depth])
         pos = self.line_number if config.preserve_position else 0
         msg = REX_COLOR.sub('', self.message).strip()
-        msg = REX_COLOR_NBQA.sub('', self.message).strip()
+        msg = REX_COLOR_NBQA.sub('', msg).strip()
         msg = REX_LINE_IN_MSG.sub('defined on line 0', msg)
         line = f'{path}:{pos}: {self.severity}: {msg}'
         if self.category != 'note':

--- a/mypy_baseline/commands/_filter.py
+++ b/mypy_baseline/commands/_filter.py
@@ -37,12 +37,13 @@ class Filter(Command):
                 unresolved_errors.append(error)
 
         fixed_errors: list[Error] = []
-        for line in baseline:
-            error = Error.new(line)
-            if error is None:
-                print(f'invalid baseline, cannot parse line: {line}')
-                return 1
-            fixed_errors.append(error)
+        if baseline != [""]: # When there are no errors, baseline is empty
+            for line in baseline:
+                error = Error.new(line)
+                if error is None:
+                    print(f'invalid baseline, cannot parse line: {line}')
+                    return 1
+                fixed_errors.append(error)
 
         fixed_count = len(fixed_errors)
         new_count = len(new_errors)

--- a/mypy_baseline/commands/_filter.py
+++ b/mypy_baseline/commands/_filter.py
@@ -37,13 +37,15 @@ class Filter(Command):
                 unresolved_errors.append(error)
 
         fixed_errors: list[Error] = []
-        if baseline != [""]: # When there are no errors, baseline is empty
-            for line in baseline:
-                error = Error.new(line)
-                if error is None:
-                    print(f'invalid baseline, cannot parse line: {line}')
-                    return 1
-                fixed_errors.append(error)
+
+        for line in baseline:
+            if not line:  # Skip empty lines
+                continue
+            error = Error.new(line)
+            if error is None:
+                print(f'invalid baseline, cannot parse line: {line}')
+                return 1
+            fixed_errors.append(error)
 
         fixed_count = len(fixed_errors)
         new_count = len(new_errors)

--- a/tests/test_commands/helpers.py
+++ b/tests/test_commands/helpers.py
@@ -8,7 +8,8 @@ from mypy_baseline import main
 LINE1 = 'views.py:69: error: Hello world  [assignment]\r\n'
 LINE2 = 'settings.py:42: error: How are you?  [union-attr]\r\n'
 LINE3 = 'python/utils.py:15: error: Second argument of Enum() must be string  [misc]\n'
-
+LINE_WITH_NOTE = 'integrations/services.py:0: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports'  # noqa: E501
+SUCCESS_LINE = 'Success: no issues found in 26 source files'
 NOTEBOOK_LINE1 = 'fail.ipynb:cell_1:2: \x1b[1m\x1b[31merror:\x1b(B\x1b[m Incompatible return value type (got \x1b(B\x1b[m\x1b[1m"int"\x1b(B\x1b[m, expected \x1b(B\x1b[m\x1b[1m"str"\x1b(B\x1b[m)  \x1b(B\x1b[m\x1b[33m[return-value]\x1b(B\x1b[m\n'  # noqa: E501
 
 

--- a/tests/test_commands/test_filter.py
+++ b/tests/test_commands/test_filter.py
@@ -4,7 +4,9 @@ from io import StringIO
 
 from mypy_baseline import main
 
-from .helpers import LINE1, LINE2, LINE3, NOTEBOOK_LINE1, run
+from .helpers import (
+    LINE1, LINE2, LINE3, LINE_WITH_NOTE, NOTEBOOK_LINE1, SUCCESS_LINE, run,
+)
 
 
 def test_filter():
@@ -12,18 +14,20 @@ def test_filter():
     stdin.write(LINE1)
     stdin.write(LINE2)
     stdin.write(LINE3)
+    stdin.write(LINE_WITH_NOTE)
     stdin.seek(0)
     stdout = StringIO()
     code = main(['filter'], stdin, stdout)
-    assert code == 3
-    stdout.seek(0)
-    actual = stdout.read()
+    assert code == 4
+    actual = stdout.getvalue()
     assert LINE1.strip() in actual
     assert LINE2.strip() in actual
     assert LINE3.strip() in actual
+    assert LINE_WITH_NOTE.strip() in actual
     assert '  assignment  ' in actual
     assert '  union-attr  ' in actual
     assert '  unresolved' in actual
+    assert ' note ' in actual
     assert 'Your changes introduced' in actual
 
 
@@ -35,8 +39,7 @@ def test_filter_notebook():
     stdout = StringIO()
     code = main(['filter'], stdin, stdout)
     assert code == 1
-    stdout.seek(0)
-    actual = stdout.read()
+    actual = stdout.getvalue()
     assert NOTEBOOK_LINE1 in actual
     assert '  return-value  ' in actual
     assert '  unresolved' in actual
@@ -46,3 +49,14 @@ def test_filter_notebook():
 def test_filter__empty_stdin():
     actual = run(['filter'])
     assert actual == ''
+
+
+def test_filter_success():
+    stdin = StringIO()
+    stdin.write(SUCCESS_LINE)
+    stdin.seek(0)
+    stdout = StringIO()
+    code = main(['filter'], stdin, stdout)
+    assert code == 0
+    actual = stdout.getvalue()
+    assert actual == SUCCESS_LINE

--- a/tests/test_commands/test_history.py
+++ b/tests/test_commands/test_history.py
@@ -5,11 +5,8 @@ from pathlib import Path
 from .helpers import run
 
 
-PROJECT_ROOT = Path(__file__).parent.parent.parent
-
-
-def test_history():
-    readme_path = PROJECT_ROOT / 'README.md'
+def test_history(request):
+    readme_path = Path(request.config.rootdir, 'README.md')
     cmd = ['history', '--baseline-path', str(readme_path), '--no-color']
     actual = run(cmd)
     exp = '2022-09-01 11:45:28+02:00  60 =   3   -1  +58   8fe7afd10c  git@orsinium.dev'


### PR DESCRIPTION
This PR fixes : 
- unused `msg` var as the following line calls `self.message`, rather than I assumed the intended `msg`
- The case where mypy has no errors and all fixes are synced, mypy-baseline exits with `invalid baseline, cannot parse line`

This is with mypy `1.3.0` .