### PR TITLE
Add support for pyi files

### DIFF
--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 REX_COLOR = re.compile('(\x1b\\[\\d*m?|\x0f)*')
 REX_COLOR_NBQA = re.compile(r'\[\d*\x1bm|\x1b|\(B')
 REX_LINE = re.compile(r"""
-    (?P<path>.+\.py):
+    (?P<path>.+\.pyi?):
     (?P<lineno>[0-9]+):\s
     (?P<severity>[a-z]+):\s
     (?P<message>.+?)

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -30,3 +30,19 @@ def test_line2_parse():
     assert e.message == 'This violates the Liskov substitution principle'
     assert e.category == 'note'
     assert e.get_clean_line(Config()) == LINE2EXP
+
+
+# pyi files
+LINE3 = 'my_project/api/views.pyi:0: note: This violates the Liskov substitution principle\r\n'  # noqa
+LINE3EXP = 'my_project/api/views.pyi:0: note: This violates the Liskov substitution principle'  # noqa
+
+
+def test_line3_parse():
+    e = Error.new(LINE3)
+    assert e is not None
+    assert e.path.parts == ('my_project', 'api', 'views.pyi')
+    assert e.line_number == 0
+    assert e.severity == 'note'
+    assert e.message == 'This violates the Liskov substitution principle'
+    assert e.category == 'note'
+    assert e.get_clean_line(Config()) == LINE3EXP


### PR DESCRIPTION
`mypy` will also display errors in `.pyi` stub files. This change allows `mypy-baseline` to also capture those errors.

Steps to reproduce:
```bash
echo "def thing(bar): ..." > foo.pyi
mypy --strict foo.pyi | mypy-baseline sync
```

In 0.5.1, the `mypy` error will be displayed in stdout and not appear in `mypy-baseline.txt`. With this change, the error is not displayed and included in `mypy-baseline.txt`