### PR TITLE
feat: Add support for --show-column-numbers output

### DIFF
--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -20,10 +20,9 @@ REX_LINE = re.compile(r"""
     (?:\s\s\[(?P<category>[a-z-]+)\])?
     \s*
 """, re.VERBOSE | re.MULTILINE)
-REX_LINE_COLUMN = re.compile(r"""
+REX_LINE = re.compile(r"""
     (?P<path>.+\.pyi?):
-    (?P<lineno>[0-9]+):
-    (?P<columnno>[0-9]+):\s
+    (?P<lineno>[0-9]+):(?:[0-9]+:)?\s
     (?P<severity>[a-z]+):\s
     (?P<message>.+?)
     (?:\s\s\[(?P<category>[a-z-]+)\])?
@@ -53,7 +52,7 @@ class Error:
     @classmethod
     def new(self, line: str) -> Error | None:
         line = _remove_color_codes(line)
-        match = REX_LINE.fullmatch(line) or REX_LINE_NBQA.fullmatch(line) or REX_LINE_COLUMN.fullmatch(line)
+        match = REX_LINE.fullmatch(line) or REX_LINE_NBQA.fullmatch(line)
         if match is None:
             return None
         return Error(line, match)

--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -20,6 +20,15 @@ REX_LINE = re.compile(r"""
     (?:\s\s\[(?P<category>[a-z-]+)\])?
     \s*
 """, re.VERBOSE | re.MULTILINE)
+REX_LINE_COLUMN = re.compile(r"""
+    (?P<path>.+\.pyi?):
+    (?P<lineno>[0-9]+):
+    (?P<columnno>[0-9]+):\s
+    (?P<severity>[a-z]+):\s
+    (?P<message>.+?)
+    (?:\s\s\[(?P<category>[a-z-]+)\])?
+    \s*
+""", re.VERBOSE | re.MULTILINE)
 REX_LINE_NBQA = re.compile(r"""
     (?P<path>.+\.ipynb:cell_[0-9]+):
     (?P<lineno>[0-9]+):\s
@@ -44,7 +53,7 @@ class Error:
     @classmethod
     def new(self, line: str) -> Error | None:
         line = _remove_color_codes(line)
-        match = REX_LINE.fullmatch(line) or REX_LINE_NBQA.fullmatch(line)
+        match = REX_LINE.fullmatch(line) or REX_LINE_NBQA.fullmatch(line) or REX_LINE_COLUMN.fullmatch(line)
         if match is None:
             return None
         return Error(line, match)

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -46,3 +46,18 @@ def test_line3_parse():
     assert e.message == 'This violates the Liskov substitution principle'
     assert e.category == 'note'
     assert e.get_clean_line(Config()) == LINE3EXP
+
+# --show-column-numbers files
+LINE4 = 'my_project/api/views.py:10:42: note: This violates the Liskov substitution principle\r\n'  # noqa
+LINE4EXP = 'my_project/api/views.py:0: note: This violates the Liskov substitution principle'  # noqa
+
+
+def test_line4_parse():
+    e = Error.new(LINE4)
+    assert e is not None
+    assert e.path.parts == ('my_project', 'api', 'views.py')
+    assert e.line_number == 10
+    assert e.severity == 'note'
+    assert e.message == 'This violates the Liskov substitution principle'
+    assert e.category == 'note'
+    assert e.get_clean_line(Config()) == LINE4EXP


### PR DESCRIPTION
Add support for parsing mypy output when it includes column numbers. This allows mypy_baseline to work with configs that include this option.