### PR TITLE
Add support for sorting baseline output

### DIFF
--- a/mypy_baseline/_config.py
+++ b/mypy_baseline/_config.py
@@ -29,6 +29,7 @@ class Config:
     depth: int = 40
     allow_unsynced: bool = False
     preserve_position: bool = False
+    sort_baseline: bool = False
     hide_stats: bool = False
     no_colors: bool = bool(os.environ.get('NO_COLOR'))
     ignore: list[str] = dataclasses.field(default_factory=list)
@@ -67,6 +68,10 @@ class Config:
         add(
             '--preserve-position', action='store_true',
             help='do not remove line number from the baseline.',
+        )
+        add(
+            '--sort-baseline', action='store_true',
+            help='sort the baseline file.',
         )
         add(
             '--hide-stats', action='store_true',

--- a/mypy_baseline/commands/_sync.py
+++ b/mypy_baseline/commands/_sync.py
@@ -28,6 +28,9 @@ class Sync(Command):
             clean_line = error.get_clean_line(self.config)
             new_baseline.append(clean_line)
 
+        if self.config.sort_baseline:
+            new_baseline.sort()
+
         synced = False
         if old_baseline:
             synced = self._stable_sync(old_baseline, new_baseline)
@@ -44,9 +47,13 @@ class Sync(Command):
         Currently, we can do a stable sync only when there are no new lines added.
         It's hard to insert new lines in the correct positions, and adding them
         at the end of the file will cause merge conflicts.
-        Sorting lines alphabetically would solve the issue, but I want to keep
-        backward compatibility.
+        Sorting lines solves the issue, so we don't use stable sync when the output
+        is sorted.
+        However, sorting is not enabled by default because I want to keep backward
+        compatibility.
         """
+        if not self.config.sort_baseline:
+            return False
         old_set = set(old_bline)
         new_set = set(new_bline)
         removed = old_set - new_set

--- a/tests/test_commands/test_sync.py
+++ b/tests/test_commands/test_sync.py
@@ -34,3 +34,19 @@ def test_sync_notebook(tmp_path: Path):
     actual = blpath.read_text()
     line1 = actual.splitlines()[0]
     assert line1 == 'fail.ipynb:cell_1:0: error: Incompatible return value type (got "int", expected "str")  [return-value]'  # noqa: E501
+
+
+def test_sync_sorted(tmp_path: Path):
+    blpath = tmp_path / 'bline.txt'
+    stdin = StringIO()
+    stdin.write(LINE1)
+    stdin.write(LINE2)
+    stdin.write(LINE3)
+    stdin.seek(0)
+    code = main(['sync', '--sort-baseline', '--baseline-path', str(blpath)], stdin, StringIO())  # noqa: E501
+    assert code == 0
+    actual = blpath.read_text()
+    line1, line2, line3 = actual.splitlines()
+    assert line1 == 'python/utils.py:0: error: Second argument of Enum() must be string  [misc]'  # noqa: E501s
+    assert line2 == 'settings.py:0: error: How are you?  [union-attr]'
+    assert line3 == 'views.py:0: error: Hello world  [assignment]'


### PR DESCRIPTION
Add a `--sort-baseline` flag that sorts the baseline output when enabled. The main aim is to decrease Git noise/conflicts when the `mypy` output ordering changes.

I've put this behaviour behind a flag because I can see from your [comment](https://github.com/orsinium-labs/mypy-baseline/blob/31384a3e00c5d9a1a9efdf071ffac0e48ec72637/mypy_baseline/commands/_sync.py#L47) that you don't want this to be the default.