### PR TITLE
fix ignoring pyproject.toml config

### DIFF
--- a/mypy_baseline/_config.py
+++ b/mypy_baseline/_config.py
@@ -62,23 +62,23 @@ class Config:
         )
 
         add(
-            '--allow-unsynced', action='store_true',
+            '--allow-unsynced', action='store_const', const=True,
             help='do not fail for resolved violations.'
         )
         add(
-            '--preserve-position', action='store_true',
+            '--preserve-position', action='store_const', const=True,
             help='do not remove line number from the baseline.',
         )
         add(
-            '--sort-baseline', action='store_true',
+            '--sort-baseline', action='store_const', const=True,
             help='sort the baseline file.',
         )
         add(
-            '--hide-stats', action='store_true',
+            '--hide-stats', action='store_const', const=True,
             help='do not show stats at the end.',
         )
         add(
-            '--no-colors', action='store_true',
+            '--no-colors', action='store_const', const=True,
             help='disable colored output. Has no effect on the output of mypy.',
         )
         add(


### PR DESCRIPTION
Hi! We faced the problem that mypy-baseline's config in pyproject.toml is completely ignored for boolean flags.
I did some investigations and here's what I found:

#### Config is read:
```python
@classmethod
def from_args(cls, args: dict[str, Any]) -> Config:
    config = cls()
    config = config.read_file(args['config'])
    config = config.read_args(args)  # <-- args overwrite config (which is the right thing)
    if isinstance(config.baseline_path, str):
        config.baseline_path = Path(config.baseline_path)
    return config
```

#### Args are read:

```python
def read_args(self, args: dict[str, Any]) -> Config:
    config = dataclasses.replace(self)
    for field in dataclasses.fields(self):
        value = args[field.name]
        if value is not None:  # <-- set only if arg is not None
            setattr(config, field.name, value)
    return config
```


#### But parser args are defined this way:

```python
add(
    '--allow-unsynced', action='store_true',
    help='do not fail for resolved violations.'
)
add(
    '--preserve-position', action='store_true',
    help='do not remove line number from the baseline.',
)
```

In this case, `store_true` acts like an on/off switch. If an argument is not set, it defaults to `False` (what is `not None`)

Thus, all the unspecified flags in the CLI overwrite any flags from the config