### PR TITLE
Add the --add-baseline-file-if-missing-then-fail flag to the filter command

### DIFF
--- a/mypy_baseline/_config.py
+++ b/mypy_baseline/_config.py
@@ -35,6 +35,7 @@ class Config:
     ignore: list[str] = dataclasses.field(default_factory=list)
     ignore_categories: list[str] = dataclasses.field(default_factory=list)
     default_branch: str = ''
+    add_baseline_file_if_missing_then_fail: bool = False
 
     @classmethod
     def from_args(cls, args: dict[str, Any]) -> Config:
@@ -92,6 +93,10 @@ class Config:
         add(
             '--default-branch',
             help='default git branch name.',
+        )
+        add(
+            '--add-baseline-file-if-missing-then-fail', action='store_true',
+            help='create the baseline file if it does not exist, then fail.',
         )
 
     def read_file(self, path: Path) -> Config:

--- a/mypy_baseline/commands/_filter.py
+++ b/mypy_baseline/commands/_filter.py
@@ -11,14 +11,17 @@ class Filter(Command):
     """
 
     def run(self) -> int:
+        baseline_missing = False
         try:
             baseline_text = self.config.baseline_path.read_text(encoding='utf8')
         except FileNotFoundError:
+            baseline_missing = True
             baseline_text = ''
         baseline = baseline_text.splitlines()
 
         unresolved_errors: list[Error] = []
         new_errors: list[Error] = []
+        baseline_content: list[str] = []
 
         for line in self.stdin:
             error = Error.new(line)
@@ -30,6 +33,11 @@ class Filter(Command):
             if self.config.is_ignored_category(error.category):
                 continue
             clean_line = error.get_clean_line(self.config)
+            
+            if baseline_missing and self.config.add_baseline_file_if_missing_then_fail:
+                baseline_content.append(clean_line)
+                continue
+                
             try:
                 baseline.remove(clean_line)
             except ValueError:
@@ -37,6 +45,15 @@ class Filter(Command):
                 new_errors.append(error)
             else:
                 unresolved_errors.append(error)
+        
+        # If baseline was missing and flag is set, create it and fail
+        if baseline_missing and self.config.add_baseline_file_if_missing_then_fail:
+            baseline_text = '\n'.join(baseline_content)
+            if baseline_content:
+                baseline_text += '\n'
+            self.config.baseline_path.write_text(baseline_text, encoding='utf8')
+            self.print(f'Created baseline file: {self.config.baseline_path}')
+            return 1
 
         fixed_errors: list[Error] = []
 

--- a/tests/test_commands/test_filter.py
+++ b/tests/test_commands/test_filter.py
@@ -82,3 +82,37 @@ def test_filter_success():
     assert code == 0
     actual = stdout.getvalue()
     assert actual == SUCCESS_LINE
+
+
+def test_filter__add_baseline_file_if_missing_then_fail(tmp_path):
+    baseline_path = tmp_path / 'test-baseline.txt'
+    stdin = StringIO()
+    stdin.write(LINE1)
+    stdin.write(LINE2)
+    stdin.seek(0)
+    stdout = StringIO()
+    code = main(['filter', '--baseline-path', str(baseline_path), '--add-baseline-file-if-missing-then-fail'], stdin, stdout)
+    assert code == 1
+    actual = stdout.getvalue()
+    assert f'Created baseline file: {baseline_path}' in actual
+    
+    # Check that baseline file was created with correct content
+    assert baseline_path.exists()
+    baseline_content = baseline_path.read_text(encoding='utf8')
+    assert 'views.py:0: error: Hello world  [assignment]' in baseline_content
+    assert 'settings.py:0: error: How are you?  [union-attr]' in baseline_content
+
+
+def test_filter__add_baseline_file_if_missing_then_fail_with_existing_file(tmp_path):
+    baseline_path = tmp_path / 'test-baseline.txt'
+    baseline_path.write_text('views.py:0: error: Hello world  [assignment]\n', encoding='utf8')
+    
+    stdin = StringIO()
+    stdin.write(LINE1)
+    stdin.seek(0)
+    stdout = StringIO()
+    code = main(['filter', '--baseline-path', str(baseline_path), '--add-baseline-file-if-missing-then-fail'], stdin, stdout)
+    assert code == 0
+    actual = stdout.getvalue()
+    assert 'Created baseline file:' not in actual
+    assert 'unresolved:' in actual


### PR DESCRIPTION
Add the `--add-baseline-file-if-missing-then-fail` flag to the filter command, allowing convenient use when runninng mypy from an automated workflow such as in `pre-commit`.

The flag works as follows:
 - When `--add-baseline-file-if-missing-then-fail` is used and the baseline file doesn't exist, it collects all mypy errors from stdin
 - Creates the baseline file with the clean error lines (processed according to config settings)
 - Prints a message indicating the baseline file was created
 - Exits with code 1 to indicate failure

When the baseline file already exists, the command operates normally, filtering errors against the existing baseline.