### PR TITLE
fix: pass path directly to toml.load() instead of opening file

### DIFF
--- a/mypy_baseline/_config.py
+++ b/mypy_baseline/_config.py
@@ -103,8 +103,7 @@ class Config:
             with path.open('rb') as stream:
                 data = tomli.load(stream)
         elif toml is not None:
-            with path.open('rb', encoding='utf8') as stream:
-                data = dict(toml.load(stream))
+            data = dict(toml.load(path))
         else:
             return self
 


### PR DESCRIPTION
The fallback path for the `toml` library opened the file in binary mode
with an encoding argument (`open('rb', encoding='utf8')`), which raises
a ValueError since binary mode doesn't accept encoding. Rather than
fixing the open mode, pass the path directly to `toml.load()` which
accepts file paths natively and handles encoding internally.