### PR TITLE
fix: remove dead REX_LINE regex definition

### DIFF
--- a/mypy_baseline/_error.py
+++ b/mypy_baseline/_error.py
@@ -14,14 +14,6 @@ REX_COLOR = re.compile('(\x1b\\[\\d*m?|\x0f)*')
 REX_COLOR_NBQA = re.compile(r'\[\d*\x1bm|\x1b|\(B')
 REX_LINE = re.compile(r"""
     (?P<path>.+\.pyi?):
-    (?P<lineno>[0-9]+):\s
-    (?P<severity>[a-z]+):\s
-    (?P<message>.+?)
-    (?:\s\s\[(?P<category>[a-z-]+)\])?
-    \s*
-""", re.VERBOSE | re.MULTILINE)
-REX_LINE = re.compile(r"""
-    (?P<path>.+\.pyi?):
     (?P<lineno>[0-9]+):(?:[0-9]+:)?\s
     (?P<severity>[a-z]+):\s
     (?P<message>.+?)


### PR DESCRIPTION
The first REX_LINE definition (without optional column number matching)
was immediately overwritten by the second definition, making it dead
code. The second definition is the correct one as it handles the
optional column number in mypy output (e.g. "file.py:1:2: error").